### PR TITLE
use torbox created date for mounts

### DIFF
--- a/functions/fuseFilesystemFunctions.py
+++ b/functions/fuseFilesystemFunctions.py
@@ -5,6 +5,7 @@ import stat
 import errno
 from functions.torboxFunctions import getDownloadLink, downloadFile
 import time
+from datetime import datetime
 import sys
 import logging
 from functions.appFunctions import getAllUserDownloads
@@ -163,10 +164,10 @@ class TorBoxMediaCenterFuse(Fuse):
         st.st_atime = now
         st.st_mtime = now
         st.st_ctime = now
-        
+
         st.st_uid = os.getuid()
         st.st_gid = os.getgid()
-        
+
         if self.vfs.is_dir(path):
             st.st_mode = stat.S_IFDIR | 0o755
             st.st_nlink = 2
@@ -178,8 +179,16 @@ class TorBoxMediaCenterFuse(Fuse):
             st.st_mode = stat.S_IFREG | 0o444
             st.st_nlink = 1
             st.st_size = file_info.get('file_size', 0)
+            created_at = file_info.get('created_at')
+            if created_at:
+                try:
+                    ts = int(datetime.fromisoformat(created_at.replace("Z", "+00:00")).timestamp())
+                    st.st_mtime = ts
+                    st.st_ctime = ts
+                except (ValueError, AttributeError):
+                    pass  # fall back to current time already set above
             return st
-            
+
         # Not found
         return -errno.ENOENT
     

--- a/functions/stremFilesystemFunctions.py
+++ b/functions/stremFilesystemFunctions.py
@@ -1,6 +1,7 @@
 import os
 import glob
 import logging
+from datetime import datetime
 from library.app import RAW_MODE
 from library.filesystem import MOUNT_PATH
 from functions.appFunctions import getAllUserDownloads
@@ -59,9 +60,18 @@ def generateStremFile(file_path: str, url: str, type: str, file_name: str, downl
         full_path = os.path.join(MOUNT_PATH, type, file_path)
     try:
         os.makedirs(full_path, exist_ok=True)
-        with open(f"{full_path}/{file_name}.strm", "w") as file:
+        strm_file_path = f"{full_path}/{file_name}.strm"
+        with open(strm_file_path, "w") as file:
             file.write(url)
-        logging.debug(f"Created strm file: {full_path}/{file_name}.strm")
+        if download:
+            created_at = download.get("created_at")
+            if created_at:
+                try:
+                    ts = datetime.fromisoformat(created_at.replace("Z", "+00:00")).timestamp()
+                    os.utime(strm_file_path, (ts, ts))
+                except (ValueError, AttributeError, OSError):
+                    pass  # fall back to current time set by the OS
+        logging.debug(f"Created strm file: {strm_file_path}")
         return True
     except FileNotFoundError as e:
         logging.error(f"Error creating strm file (likely bad naming scheme of file): {e}")

--- a/functions/torboxFunctions.py
+++ b/functions/torboxFunctions.py
@@ -47,7 +47,8 @@ def process_file(item, file, type):
         "file_mimetype": file.get("mimetype"),
         "path": file.get("name"),
         "download_link": f"https://api.torbox.app/v1/api/{type.value}/requestdl?token={TORBOX_API_KEY}&{IDType[type.value].value}={item.get('id')}&file_id={file.get('id')}&redirect=true",
-        "extension": os.path.splitext(file.get("short_name"))[-1],              
+        "extension": os.path.splitext(file.get("short_name"))[-1],
+        "created_at": item.get("created_at"),
     }
     title_data = PTN.parse(file.get("short_name"))
 


### PR DESCRIPTION
feat: preserve torbox create timestamps on strm and fuse mounts

Propagate the `created_at` attribute from TorBox items through to
mounted files so timestamps reflect the original upload date rather than the
time of local file creation. This allows media libraries to not see files as 'new'