### PR TITLE
fix: don't throw on redirect

### DIFF
--- a/functions/torboxFunctions.py
+++ b/functions/torboxFunctions.py
@@ -194,7 +194,7 @@ def searchMetadata(query: str, title_data: dict, file_name: str, full_title: str
 
 def getDownloadLink(url: str):
     response = requestWrapper(general_http_client, "GET", url)
-    if response.status_code == httpx.codes.TEMPORARY_REDIRECT or response.status_code == httpx.codes.PERMANENT_REDIRECT or response.status_code == httpx.codes.FOUND:
+    if response.has_redirect_location:
         return response.headers.get('Location')
     return url
 

--- a/library/http.py
+++ b/library/http.py
@@ -89,6 +89,9 @@ def requestWrapper(client: httpx.Client, method: str, url: str, use_cache: bool 
             
             return response
         except httpx.HTTPStatusError as e:
+            if e.response.has_redirect_location:
+                return e.response
+
             bad_response_codes = [429]
             if e.response.status_code in bad_response_codes:
                 wait_time = backoff_factor * (2 ** attempt)


### PR DESCRIPTION
- `requestWrapper` wasn't properly returning redirect responses for clients where `follow_redirects=False`.
- use redirect helper from httpx client instead of hard-coding redirect status codes