### PR TITLE
Fix redirect handling for requestdl links and disable cache for ranged downloads

### DIFF
--- a/functions/torboxFunctions.py
+++ b/functions/torboxFunctions.py
@@ -194,7 +194,7 @@ def searchMetadata(query: str, title_data: dict, file_name: str, full_title: str
 
 def getDownloadLink(url: str):
     response = requestWrapper(general_http_client, "GET", url)
-    if response.status_code == httpx.codes.TEMPORARY_REDIRECT or response.status_code == httpx.codes.PERMANENT_REDIRECT or response.status_code == httpx.codes.FOUND:
+    if response.has_redirect_location:
         return response.headers.get('Location')
     return url
 

--- a/functions/torboxFunctions.py
+++ b/functions/torboxFunctions.py
@@ -203,7 +203,7 @@ def downloadFile(url: str, size: int, offset: int = 0):
         "Range": f"bytes={offset}-{offset + size - 1}",
         **general_http_client.headers,
     }
-    response = requestWrapper(general_http_client, "GET", url, headers=headers)
+    response = requestWrapper(general_http_client, "GET", url, use_cache=False, headers=headers)
     if response.status_code == httpx.codes.OK:
         return response.content
     elif response.status_code == httpx.codes.PARTIAL_CONTENT:

--- a/library/http.py
+++ b/library/http.py
@@ -89,6 +89,12 @@ def requestWrapper(client: httpx.Client, method: str, url: str, use_cache: bool 
             
             return response
         except httpx.HTTPStatusError as e:
+            if e.response.has_redirect_location:
+                if cacheable and cache_key:
+                    _cache[cache_key] = (time.time(), e.response)
+                    logging.debug(f"Cached redirect response for {url}")
+                return e.response
+
             bad_response_codes = [429]
             if e.response.status_code in bad_response_codes:
                 wait_time = backoff_factor * (2 ** attempt)


### PR DESCRIPTION
## Summary

This PR fixes two issues affecting FUSE playback, especially with Plex:

1. `requestdl?redirect=true` links could fail because redirect responses were treated as errors instead of valid link-resolution responses.
2. HTTP range reads could return corrupted data because ranged downloads were going through the generic GET cache.

These issues caused:
- broken playback unless users monkeypatched redirect handling
- corrupted reads once playback crossed cached block boundaries

---

## Fixes

### 1. Handle redirect responses when resolving download links

`getDownloadLink()` intentionally uses a client with `follow_redirects=False` in order to resolve `requestdl?redirect=true` into the final CDN URL.

However, `requestWrapper()` called `response.raise_for_status()` and treated redirect responses as errors, so valid redirect responses were not returned to the caller.

This PR changes `requestWrapper()` to return redirect responses when `response.has_redirect_location` is true, and updates `getDownloadLink()` to use `response.has_redirect_location` instead of checking only a small hard-coded subset of redirect status codes.

### 2. Disable HTTP caching for ranged downloads

`downloadFile()` performs ranged GET requests using the `Range` header.

Those requests should not go through the generic GET cache. In practice, doing so could cause incorrect block reuse and corrupted multi-block reads in the FUSE path.

This PR makes `downloadFile()` explicitly call:

```python
requestWrapper(..., use_cache=False, headers=headers)
```

This keeps the existing higher-level FUSE block cache intact, while preventing the HTTP client cache from interfering with ranged reads.

---

## Reproduction

A reproducible case was observed with Plex + FUSE mount:

- direct HTTP ranged reads from the TorBox CDN URL were correct
- FUSE-mounted reads matched direct HTTP for small reads inside a single block
- once reads crossed the configured FUSE block boundary, the mounted file diverged from the direct HTTP content
- Plex playback could start, but seeking or longer reads would fail

---

## Result

With this patch:
- redirect-based download link resolution works without monkeypatching
- ranged reads no longer go through the generic HTTP cache
- checksum comparisons between direct HTTP and FUSE reads match in the reproduced case
- Plex playback/seek behavior is restored for the failing case

---

## Notes

This PR intentionally keeps the existing FUSE block cache design and only prevents the lower-level HTTP cache from interfering with ranged downloads.